### PR TITLE
indentation fix for clone links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A collection of all popular Data Structure and Algorithm. You can contribute by 
 1. Access your new fork on your account in the repositories and clone it:
 1. Cloning process can be carried out by the following methods ->
     1. Click on Clone or download button on forked repo and download zip 
-    1. Open terminal/Git bash and use
-    https: ` git clone https://github.com/arghac14/DataStructure-and-Algorithms.git `
-    ssh: `git@github.com:YourUserName/DataStructure-and-Algorithms.git`
+    1. Open terminal/Git bash and use  
+    https: ` git clone https://github.com/arghac14/DataStructure-and-Algorithms.git `  
+    ssh: `git@github.com:YourUserName/DataStructure-and-Algorithms.git`  
         
 1. Add new Data Structure and Algorithms that don't already exist in the original repo.
 1. Push the changes and make a PR!


### PR DESCRIPTION
The links were on same line for cloning the project, which made visibility harder for the cloning.

Before:
![Screenshot from 2019-10-30 20-33-22](https://user-images.githubusercontent.com/15843175/67868787-8cd36680-fb54-11e9-9835-172b67029d78.png)


After:
![Screenshot from 2019-10-30 20-34-15](https://user-images.githubusercontent.com/15843175/67868928-c0ae8c00-fb54-11e9-88ad-9d619b6cfc13.png)
